### PR TITLE
Create subscription items on subscription creation/update

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -17,7 +17,8 @@ module StripeMock
             subscriptions_items[item_id] =
               Data.mock_subscription_item({ id: item_id, plan: plan, quantity: quantity })
           else
-            subscriptions_items[item_id] = Data.mock_subscription_item({ id: item_id, plan: plan })
+            subscriptions_items[item_id] =
+              Data.mock_subscription_item({ id: item_id, plan: plan })
           end
           subscriptions_items[item_id]
         end

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -11,10 +11,9 @@ module StripeMock
         items = options[:items]
         items = items.values if items.respond_to?(:values)
         subscription[:items][:data] = plans.map do |plan|
-          item_id = new_id('si')
-          if items && items.size == plans.size
-            quantity = items &&
-              items.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
+          item_id = item[:id] || new_id('si')
+          if items
+            quantity = items.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
             subscriptions_items[item_id] =
               Data.mock_subscription_item({ id: item_id, plan: plan, quantity: quantity })
           else

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -257,7 +257,7 @@ module StripeMock
                    elsif params[:items]
                      items = params[:items]
                      items = items.values if items.respond_to?(:values)
-                     items.map { |item| item[:plan].to_s if item[:plan] }
+                     items.map { |item| item[:plan].to_s if item[:plan] }.compact
                    else
                      []
                    end


### PR DESCRIPTION
* instead of just mocking the sub items, i'm creating an actual sub item so that we can retrieve it in other parts of the code
* added a `.compact` to the plans because it was erroring out on "nil" ids 